### PR TITLE
[PR] 게시물 작성 페이지 구현

### DIFF
--- a/fe/src/Write/HashtagInput.jsx
+++ b/fe/src/Write/HashtagInput.jsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+import './css/HashtagInput.css';
+
+const SEPERATOR = ',';
+
+function HashtagInput() {
+  const [hashtagList, setHashtagList] = useState([]);
+  const [inputState, setInputState] = useState('');
+
+  const handleHashTagList = (content) => {
+    const lastChar = content.charAt(content.length - 1);
+    if (lastChar === SEPERATOR) {
+      if (inputState === '') {
+        setInputState(() => '');
+      } else {
+        const newList = [...hashtagList, content.substr(0, content.length - 1)];
+        setHashtagList(() => newList);
+        setInputState(() => '');
+      }
+    }
+  };
+
+  const onChange = (e) => {
+    setInputState(() => e.target.value);
+    handleHashTagList(e.target.value);
+  };
+
+  const onKeyPress = (e) => {
+    if (e.key === 'Enter') {
+      if (inputState === '') return;
+      const newList = [...hashtagList, inputState];
+      setHashtagList(() => newList);
+      setInputState(() => '');
+    }
+  };
+
+  const onKeyDown = (e) => {
+    if (inputState === '') {
+      if (e.keyCode === 8) {
+        const newList = hashtagList.splice(0, hashtagList.length - 1);
+        setHashtagList(() => newList);
+      }
+    }
+  };
+  return (
+    <div className="hashtag-input-container">
+      {hashtagList.map((e) => (
+        <div className="hashtag-element">{`#${e}`}</div>
+      ))}
+      <input
+        onChange={onChange}
+        onKeyDown={onKeyDown}
+        onKeyPress={onKeyPress}
+        value={inputState}
+      />
+    </div>
+  );
+}
+
+export default HashtagInput;

--- a/fe/src/Write/Write.jsx
+++ b/fe/src/Write/Write.jsx
@@ -1,8 +1,9 @@
 import React, { useRef } from 'react';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@toast-ui/editor/dist/toastui-editor.css';
-
 import { Editor } from '@toast-ui/react-editor';
+
+import HashtagInput from './HashtagInput';
 
 function Write() {
   const editorRef = useRef();
@@ -15,7 +16,8 @@ function Write() {
   };
   return (
     <div className="write">
-      <Editor ref={editorRef} />
+      <HashtagInput />
+      <Editor ref={editorRef} initialValue="여기에 내용을 입력하세요.." />
       <button type="submit" onClick={onSubmit}>
         제출하기
       </button>

--- a/fe/src/Write/Write.jsx
+++ b/fe/src/Write/Write.jsx
@@ -1,0 +1,26 @@
+import React, { useRef } from 'react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import '@toast-ui/editor/dist/toastui-editor.css';
+
+import { Editor } from '@toast-ui/react-editor';
+
+function Write() {
+  const editorRef = useRef();
+
+  const onSubmit = () => {
+    const contentHTML = editorRef.current?.getInstance().getHTML();
+    const contentMarkdown = editorRef.current?.getInstance().getMarkdown();
+    console.log('contentHTML', contentHTML);
+    console.log('contentMarkdown', contentMarkdown);
+  };
+  return (
+    <div className="write">
+      <Editor ref={editorRef} />
+      <button type="submit" onClick={onSubmit}>
+        제출하기
+      </button>
+    </div>
+  );
+}
+
+export default Write;

--- a/fe/src/Write/css/HashtagInput.css
+++ b/fe/src/Write/css/HashtagInput.css
@@ -1,0 +1,7 @@
+.hashtag-input-container{
+    display: flex;
+}
+
+.hashtag-element{
+    color: #4e87fb;
+}


### PR DESCRIPTION
![write](https://user-images.githubusercontent.com/56749516/177673950-c10623b0-bd06-4333-a065-f84dbb2cf8ff.gif)

### 구현 사항
- 만약 해시태그 입력창이 비어있고, backspace 입력 시, 최근 해시태그 삭제
- 해시태그 입력시, enter나 comma(,) 를 통해 해시태그 추가가능
- 게시물 콘텐츠 받아오기 (일단 마크다운이랑, html 둘다 받아옵니다.)
- 게시물 제출버튼 누를시, 에디터로부터 받아온 콘텐츠 콘솔에 출력(콘솔에 출력하는 로직을 post 요청 로직으로만 바꾸면 글 등록버튼이 됩니다.)
### 추가해야 될 사항
- 해시태그가 많아질 때, 클릭으로 해시태그를 없애야 될 것 같습니다. (사용자 편의를 위해)